### PR TITLE
Fix subject meta tag to use apostrophe instead of double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inspired by/copied from http://code.lancepollard.com/complete-list-of-html-meta-
 <meta charset="UTF-8">
 <meta name="keywords" content="your, tags">
 <meta name="description" content="150 words">
-<meta name="subject" content="your website"s subject">
+<meta name="subject" content="your website's subject">
 <meta name="copyright" content="company name">
 <meta name="language" content="ES">
 <meta name="robots" content="index,follow">


### PR DESCRIPTION
Restore syntax highilighting for meta tags by fixing the "subject" meta element. 

After these changes, README.md looks like below:
![image](https://user-images.githubusercontent.com/16655020/67164698-1d36cd80-f343-11e9-8612-fc6258b28933.png)
